### PR TITLE
implement annular_fpm, and start initial unit tests

### DIFF
--- a/falco/masks.py
+++ b/falco/masks.py
@@ -1,0 +1,81 @@
+import numpy as np
+import poppy
+
+from . import utils
+
+
+def annular_fpm(pixres_fpm, rho_inner, rho_outer, fpm_amp_factor=0.0,
+        rot180=False, centering='pixel', **kwargs):
+    """Generate an annular FPM using POPPY
+    Outside the outer ring is opaque. If rho_outer = infinity, the outer
+    mask is omitted and the mask is cropped down to the size of the inner spot.
+    The inner spot has a specifyable amplitude value.
+    The output array is the smallest size that fully contains the mask.
+
+    Parameters
+    ----------
+    pixres_fpm : float
+        resolution in pixels per lambda_c/D
+    rho_inner : float
+        radius of inner FPM amplitude spot (in lambda_c/D)
+    rho_outer : float
+        radius of outer opaque FPM ring (in lambda_c/D). Set to
+        infinity for an occulting-spot-only FPM.
+    fpm_amp_factor : float
+        amplitude transmission of inner FPM spot. Default is 0.0.
+    rot180 : bool
+        Optional, flag to rotate
+    centering : string
+        Either 'pixel' or 'interpixel'
+
+    Returns
+    -------
+    mask: ndarray
+        cropped-down, 2-D FPM representation. amplitude only
+    """
+
+    dxi_ul = 1/pixres_fpm  # lambda_c/D per pixel. "UL" for unitless
+
+    offset = 1/2 if centering=='interpixel' else 0
+
+    if not np.isfinite(rho_outer):
+        # number of points across the inner diameter of the FPM.
+        narray = utils.ceil_even(2*(rho_inner/dxi_ul+offset))
+    else:
+        # number of points across the outer diameter of the FPM.
+        narray = utils.ceil_even(2*(rho_outer/dxi_ul+offset))
+
+    xshift = 0
+    yshift = 0
+    darray = narray*dxi_ul  # width of array in lambda_c/D
+
+    # 0 for pixel-centered FPM, or -diam/Narray for inter-pixel centering
+    if centering == 'interpixel':
+        cshift = -dxi_ul / 2
+    elif centering == 'pixel':
+        cshift = -dxi_ul if rot180 else 0
+
+    else:
+        raise ValueError("Invalid value for centering parameter")
+
+
+    # Method note: The algorithm in falco-matlab works in units of lambda/D. 
+    # Everything in POPPY works natively in arcseconds or meters. We can 
+    # make a shortcut here and just substitute coordinates in arcsec for lambda/D.
+    # That's fine to do for the present purposes of just drawing a circle. 
+
+    fpm = poppy.AnnularFieldStop(radius_inner = rho_inner,
+                                 radius_outer = rho_outer,
+                                 shift_x = cshift + xshift,
+                                 shift_y = cshift + yshift)
+    mask = fpm.sample(npix=narray, grid_size=darray)
+
+    if fpm_amp_factor != 0:
+        # poppy doesn't support gray circular occulting masks, but we can
+        # simulate that by just adding back some of the intensity.
+        fpm.radius_inner = 0
+        mask_no_inner = fpm.sample(npix=narray, grid_size=darray)
+        mask = mask * fpm_amp_factor + mask_no_inner * (1-fpm_amp_factor)
+
+    return mask
+

--- a/falco/tests/test_masks.py
+++ b/falco/tests/test_masks.py
@@ -1,0 +1,20 @@
+import falco.masks as masks
+import numpy as np
+
+
+def test_annular_fpm():
+    """ Quick and dirty spot check of annular_fpm
+    This test is very partial at best.
+    """
+
+    # test some semi-random cases - is the array size as expected? 
+    assert masks.annular_fpm(3, 2, np.inf).shape == (3*2*2, 3*2*2)
+    assert masks.annular_fpm(3, 5, np.inf).shape == (3*5*2, 3*5*2)
+    assert masks.annular_fpm(3, 5, 10).shape == (3*10*2, 3*10*2)
+    assert masks.annular_fpm(3, 5, 11).shape == (3*11*2, 3*11*2)
+
+    # test some pixel values are as expected. 
+    mask = masks.annular_fpm(3, 2, 10)
+    assert mask[0,0]==0 # corner is black
+    assert mask[5*10, 5*10]==1 # in between is white
+    assert mask[3*10, 3*10]==0 # center is black

--- a/falco/tests/test_utils.py
+++ b/falco/tests/test_utils.py
@@ -1,0 +1,18 @@
+import falco.utils as utils
+import numpy as np
+
+def test_ceil_even():
+    assert utils.ceil_even(1)==2
+    assert utils.ceil_even(1.5)==2
+    assert utils.ceil_even(4)==4
+    assert utils.ceil_even(3.14159)==4
+    assert utils.ceil_even(2001)==2002
+
+def test_ceil_odd():
+    assert utils.ceil_odd(1)==1
+    assert utils.ceil_odd(1.5)==3
+    assert utils.ceil_odd(4)==5
+    assert utils.ceil_odd(3.14159)==5
+    assert utils.ceil_odd(2001)==2001
+
+

--- a/falco/utils.py
+++ b/falco/utils.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+def ceil_even(x_in):
+    """Compute the next highest even integer above the input
+
+    Parameters
+    ----------
+    x_in : float
+        Scalar value
+
+    Returns
+    --------
+    x_out : integer
+        Even-valued integer
+    """
+
+    return int(2*np.ceil(0.5*x_in))
+
+def ceil_odd(x_in):
+    """Compute the next highest odd integer above the input
+
+    Parameters
+    ----------
+    x_in : float
+        Scalar value
+
+    Returns
+    --------
+    x_out : integer
+        Odd-valued integer
+    """
+    x_out = int(np.ceil(x_in))
+    if x_out % 2 == 0: x_out +=1
+    return x_out
+
+

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#2!/usr/bin/env python
 import os
 import subprocess
 import sys
@@ -66,7 +66,7 @@ except ImportError:
 class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
-        self.test_args = ['packagename/tests']
+        self.test_args = ['falco/tests']
         self.test_suite = True
 
     def run_tests(self):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#2!/usr/bin/env python
+#!/usr/bin/env python
 import os
 import subprocess
 import sys


### PR DESCRIPTION
Existence proof of implementing a function FALCO needs by calling POPPY behind the scenes. In this case the `annular_fpm` function is implemented by turning the input parameters into suitable calls to `poppy.AnnularFieldStop`. 

As part of this I also implemented `ceil_even` and `ceil_odd` but those are trivial ~ one-line functions.

Lastly I added some initial unit tests of all of the above. Not that any of these are particularly hard functions, but I wanted to put some example tests in place as a starting point.  