### PR TITLE
DM Surfaces in Differential Model 

### DIFF
--- a/falco/model/models.py
+++ b/falco/model/models.py
@@ -608,8 +608,8 @@ def compact_reverse_gradient(command_vec, mp, EestAll, log10reg):
         mp.dm2.V = mp.dm2.V0.copy()
         
         dEend = EFendB - EFendA
-        DM1surf = DM1surfB - DM1surfA
-        DM2surf = DM2surfB - DM2surfA
+        DM1surf = DM1surfB
+        DM2surf = DM2surfB
 
         # DH = EFend[mp.Fend.corr.maskBool]
         EdhNew = Eest2D + dEend


### PR DESCRIPTION
Fix dm surface handling in AD-EFC gradient calculations.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the handling of DM surfaces in the AD-EFC gradient calculations by modifying the assignment of DM1surf and DM2surf in the compact_reverse_gradient function.

- **Bug Fixes**:
    - Corrected the handling of DM surfaces in the AD-EFC gradient calculations by adjusting the assignment of DM1surf and DM2surf.

<!-- Generated by sourcery-ai[bot]: end summary -->