### PR TITLE
DM: Fix bug to actually use ZYX orientation in gen_surf_from_act()

### DIFF
--- a/falco/dm.py
+++ b/falco/dm.py
@@ -98,11 +98,18 @@ def gen_surf_from_act(dm, dx, Nout):
             raise ValueError('invalid value of dm.orientation')
 
     # Generate the DM surface
-    DMsurf = falco.dm.propcustom_dm(
-        bm, heightMap, dm.xc-cshift, dm.yc-cshift, dm.dm_spacing,
-        XTILT=dm.xtilt, YTILT=dm.ytilt, ZTILT=dm.zrot, XYZ=flagXYZ,
-        inf_sign=dm.inf_sign, inf_fn=dm.inf_fn
-    )
+    if flagXYZ:
+        DMsurf = falco.dm.propcustom_dm(
+            bm, heightMap, dm.xc-cshift, dm.yc-cshift, dm.dm_spacing,
+            XTILT=dm.xtilt, YTILT=dm.ytilt, ZTILT=dm.zrot, XYZ=True,
+            inf_sign=dm.inf_sign, inf_fn=dm.inf_fn
+            )
+    else:
+        DMsurf = falco.dm.propcustom_dm(
+            bm, heightMap, dm.xc-cshift, dm.yc-cshift, dm.dm_spacing,
+            XTILT=dm.xtilt, YTILT=dm.ytilt, ZTILT=dm.zrot, ZYX=True,
+            inf_sign=dm.inf_sign, inf_fn=dm.inf_fn
+            )
 
     # DMsurf = falco.util.pad_crop(DMsurf, Nout)
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the orientation handling in the gen_surf_from_act() function to ensure the correct use of ZYX orientation when the flagXYZ is not set.

Bug Fixes:
- Fix the orientation handling in the gen_surf_from_act() function to correctly use ZYX orientation when the flagXYZ is not set.

<!-- Generated by sourcery-ai[bot]: end summary -->