### PR TITLE
fix centering issue in create_axis for odd N

### DIFF
--- a/falco/util.py
+++ b/falco/util.py
@@ -426,7 +426,7 @@ def create_axis(N, step, centering='pixel'):
     check.real_positive_scalar(step, 'step', TypeError)
     check.centering(centering)
 
-    axis = np.arange(-N // 2, N // 2, dtype=np.float64) * step
+    axis = np.arange(np.ceil(-N/2), np.ceil(N/2), dtype=np.float64) * step
     even = not N % 2  # Even number of samples?
 
     if even and (centering == 'interpixel'):


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correctly center the axis when `N` is odd.