### PR TITLE
Make yaml loader reusable and turn off eval caching

### DIFF
--- a/falco/config/Eval.py
+++ b/falco/config/Eval.py
@@ -39,5 +39,6 @@ class Eval:
             raise ValueError("Circular parameter evaluation dependency detected.")
 
         self.in_progress = True
-
-        return eval(self.code, self.globals, self.locals)
+        result = eval(self.code, self.globals, self.locals)
+        self.in_progress = False
+        return result

--- a/falco/config/Eval.py
+++ b/falco/config/Eval.py
@@ -9,11 +9,18 @@ class Eval:
     When evaluating, it exposes numpy, falco, and math to the injected code under `np`, `falco`, and `math`,
     and the model parameters object under `mp`.
     """
-    mp: any
+
+    globals: any
     """
-    The model parameters object exposed to the injected code.
-    
-    Modifying the `mp` object after instantiating this class is OK. (and necessary in most cases)
+    The globals exposed to the injected code, in a dictionary.
+    Use this to provide libraries, i.e. `{"np": numpy}`
+    """
+
+    locals: any
+    """
+    The locals exposed to the injected code, in a dictionary.
+    This can be used to provide recursive access to the parsed config object.
+    Modifying the locals after instantiating this class is OK. (and often necessary)
     """
 
     code: str
@@ -33,8 +40,4 @@ class Eval:
 
         self.in_progress = True
 
-        import falco
-        import numpy
-        import math
-
-        return eval(self.code, {'np': numpy, 'falco': falco, 'math': math}, {'mp': self.mp})
+        return eval(self.code, self.globals, self.locals)

--- a/falco/config/Eval.py
+++ b/falco/config/Eval.py
@@ -39,6 +39,8 @@ class Eval:
             raise ValueError("Circular parameter evaluation dependency detected.")
 
         self.in_progress = True
-        result = eval(self.code, self.globals, self.locals)
-        self.in_progress = False
+        try:
+            result = eval(self.code, self.globals, self.locals)
+        finally:
+            self.in_progress = False
         return result

--- a/falco/config/ModelParameters.py
+++ b/falco/config/ModelParameters.py
@@ -205,7 +205,7 @@ class ModelParameters(Object):
         super().__init__(**kwargs)
 
     @staticmethod
-    def from_yaml(text):
+    def from_yaml(text, context=None):
         """
         Construct a ModelParameters object from a yaml string.
 
@@ -232,15 +232,20 @@ class ModelParameters(Object):
           Circular dependencies between expressions will be detected and an error will be raised.
 
         :param text: a yaml string to deserialize
+        :param context addition local variables to expose to eval code
         :return: a `ModelParameters` instance
         """
 
         result = ModelParameters()
 
+        if context is None:
+            context = dict()
+        context['mp'] = result
+
         data = load_from_str(
             text,
             {'np': numpy, 'falco': falco, 'math': math},
-            {'mp': result},
+            context,
             {
                 "!Probe": object_constructor(Probe),
                 "!ProbeSchedule": object_constructor(ProbeSchedule)
@@ -251,10 +256,10 @@ class ModelParameters(Object):
         return result
 
     @staticmethod
-    def from_yaml_file(path_string):
+    def from_yaml_file(path_string, context=None):
         """
         Reads the yaml file at the given path and passes it to `ModelParameters.from_yaml`.
 
         See `ModelParameters.from_yaml` for info.
         """
-        return ModelParameters.from_yaml(Path(path_string).read_text())
+        return ModelParameters.from_yaml(Path(path_string).read_text(), context)

--- a/falco/config/ModelParameters.py
+++ b/falco/config/ModelParameters.py
@@ -239,7 +239,7 @@ class ModelParameters(Object):
         result = ModelParameters()
 
         if context is None:
-            context = dict()
+            context = {}
         context['mp'] = result
 
         data = load_from_str(

--- a/falco/config/Object.py
+++ b/falco/config/Object.py
@@ -35,9 +35,7 @@ class Object:
             raise AttributeError
 
         if isinstance(self.data[item], Eval):
-            result = self.data[item].evaluate()
-            self.data[item] = result
-            return result
+            return self.data[item].evaluate()
         return self.data[item]
 
     def __getitem__(self, item):

--- a/falco/config/yaml_loader.py
+++ b/falco/config/yaml_loader.py
@@ -1,0 +1,50 @@
+import yaml
+from falco.config import Eval, Object
+
+def load_from_str(yaml_str, eval_globals, eval_locals, ctors_dict):
+    """
+    Loads a yaml string into a config Object.
+    Automatically provides a tag constructor for the Eval class, and
+    all dictionaries are automatically converted to the config Object class.
+
+    See Eval for more details on the globals and locals arguments.
+
+    :param yaml_str: a yaml string
+    :param eval_globals: globals to expose to eval code, in a dictionary
+    :param eval_locals: locals to expose to eval code, in a dictionary
+    :param ctors_dict: a dictionary of extra constructors, such as `{'!Probe', object_constructor(Probe)}`
+    :return a python object
+    """
+    result_obj = yaml.load(yaml_str, Loader=_get_loader(eval_globals, eval_locals, ctors_dict))
+    return result_obj.data
+
+def object_constructor(noarg_constructor):
+    """
+    Makes a yaml class loader from a class constructor that takes no arguments.
+    :param noarg_constructor: a constructor with no arguments
+    """
+    def _result(loader: yaml.SafeLoader, node: yaml.nodes.MappingNode):
+        obj = noarg_constructor(**loader.construct_mapping(node))
+        return obj
+    return _result
+
+def _eval_constructor(eval_globals, eval_locals):
+    def _result(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode):
+        s = loader.construct_scalar(node)
+        if not isinstance(s, str):
+            raise ValueError(f"Cannot eval anything other than a string. Found type {type(s)}: {s}")
+        return Eval(eval_globals, eval_locals, loader.construct_yaml_str(node))
+    return _result
+
+def _get_loader(eval_globals, eval_locals, ctors_dict):
+    """Add constructors to PyYAML loader."""
+    loader = yaml.SafeLoader
+    loader.add_constructor(u'tag:yaml.org,2002:map', object_constructor(Object))
+    loader.add_constructor("!eval", _eval_constructor(eval_globals, eval_locals))
+
+    for tag in ctors_dict:
+        loader.add_constructor(tag, ctors_dict[tag])
+    return loader
+
+
+

--- a/tests/unit/test_mp_yaml.py
+++ b/tests/unit/test_mp_yaml.py
@@ -87,7 +87,7 @@ def test_dependency():
     assert result.a == 4
 
 
-def test_cache():
+def test_no_cache():
     result = parse("""
         val: !eval 2+2
         
@@ -112,7 +112,7 @@ def test_cache():
     assert invocation_count == 1
 
     assert result.val == 4
-    assert invocation_count == 1
+    assert invocation_count == 2
 
 
 def test_circular_dependency():


### PR DESCRIPTION
This PR separates the yaml-config-file-loading logic into its own file that can be reused by other libraries (like the IACT tb lib). It gives the ability to inject other variables into the eval context. This makes it so that when loading falco and the TB lib together, falco's parameters can reference hardware configuration from the TB for things like the number of actuators.

It also turns off the caching for eval'ed code, so that we can change it without reinitializing.

## Summary by Sourcery

Refactor YAML loading mechanism to improve reusability and configuration flexibility

New Features:
- Create a new yaml_loader.py module to centralize YAML loading functionality
- Add ability to pass custom context when loading YAML configurations

Enhancements:
- Separate YAML loading logic into a reusable module that allows injecting custom variables into the evaluation context
- Modify Eval class to support more flexible global and local variable injection

Chores:
- Remove eval caching to allow dynamic configuration changes
- Simplify object initialization and evaluation process