### PR TITLE
Avoid deepcopying Eval globals

### DIFF
--- a/falco/config/Eval.py
+++ b/falco/config/Eval.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-
+import copy
 
 @dataclass
 class Eval:
@@ -44,3 +44,6 @@ class Eval:
         finally:
             self.in_progress = False
         return result
+    
+    def __deepcopy__(self, memo):
+        return Eval(self.globals, copy.deepcopy(self.locals, memo), self.code)


### PR DESCRIPTION
In my last PR I introduced a bug where when trying to pickle/deepcopy model parameters, it would try to pickle a dictionary of modules. Since that dictionary doesn't ever need to change, I just overrode the `__deepcopy__` method to avoid cloning it.