### PR TITLE
Enable installation of falco python in editable mode.

### DIFF
--- a/falco/__init__.py
+++ b/falco/__init__.py
@@ -1,7 +1,11 @@
-from falco.config import init_from_mat as ifm
+from .config import init_from_mat as ifm  # ← CHANGED: Use relative import
+from . import config
+from . import model
+from . import proper
+from . import wfsc
+
 from .setup import *
 from .util import *
-# from .configs  import *
 from .imaging import *
 from .dm import *
 from .diff_dm import *
@@ -15,7 +19,6 @@ from .prop import *
 from .hexsegmirror import *
 from .thinfilm import *
 from .zern import *
-from . import model
 from ._globals import INFLUENCE_XINETICS
 from ._globals import INFLUENCE_BMC_KILO
 from ._globals import INFLUENCE_BMC_2K


### PR DESCRIPTION
If you want to install falco in editable mode: `python -m pip install -e .` the absolute import in the init:
`from falco.config import init_from_mat as ifm`

causes the install to fail in a weird way. This has been changed to a relative import and the other modules have been imported as well.