### PR TITLE
Get subbandpass image from testbed

### DIFF
--- a/falco/config/ModelParameters.py
+++ b/falco/config/ModelParameters.py
@@ -9,6 +9,7 @@ import falco
 from falco.config.yaml_loader import object_constructor, load_from_str
 from falco.util import _spec_arg
 from falco.config import Probe, ProbeSchedule, Object
+import astropy
 
 
 class ModelParameters(Object):
@@ -251,7 +252,7 @@ class ModelParameters(Object):
 
         data = load_from_str(
             text,
-            {'np': numpy, 'falco': falco, 'math': math},
+            {'np': numpy, 'falco': falco, 'math': math, 'astropy': astropy},
             context,
             {
                 "!Probe": object_constructor(Probe),

--- a/falco/config/TestbedInterface.py
+++ b/falco/config/TestbedInterface.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+class TestbedInterface(ABC):
+    '''A general purpose interface for all testbeds to implement.'''
+
+    @abstractmethod
+    def get_sbp_image(self, subband_index):
+        pass
+

--- a/falco/est.py
+++ b/falco/est.py
@@ -23,7 +23,7 @@ def wrapper(mp, ev, jacStruct, tb = None):
         Structure containing estimation variables.
     jacStruct : ModelParameters
         Structure containing control Jacobians for each specified DM.
-    tb : pyHCIT_hwControl.interface.TestbedInterface or None
+    tb : falco.config.TestbedInterface or None
         (Optional) Control interface for a physical testbed.
 
     Returns
@@ -232,7 +232,7 @@ def pairwise_probing(mp, ev, jacStruct=np.array([]), tb = None):
     ev : falco.config.Object()
     jacStruct : array_like, optional
         Array containing the control Jacobian. Default is an empty array.
-    tb : pyHCIT_hwControl.interface.TestbedInterface or None
+    tb : falco.config.TestbedInterface or None
         (Optional) Control interface for a physical testbed.
 
     Returns

--- a/falco/est.py
+++ b/falco/est.py
@@ -9,7 +9,7 @@ import falco
 from . import check
 
 
-def wrapper(mp, ev, jacStruct):
+def wrapper(mp, ev, jacStruct, tb = None):
     """
     Select and run the chosen estimator.
 
@@ -23,6 +23,8 @@ def wrapper(mp, ev, jacStruct):
         Structure containing estimation variables.
     jacStruct : ModelParameters
         Structure containing control Jacobians for each specified DM.
+    tb : pyHCIT_hwControl.interface.TestbedInterface or None
+        (Optional) Control interface for a physical testbed.
 
     Returns
     -------
@@ -33,15 +35,15 @@ def wrapper(mp, ev, jacStruct):
 
         falco.est.perfect(mp, ev)
         with falco.util.TicToc('Getting updated summed image'):
-            ev.Im = falco.imaging.get_summed_image(mp)
+            ev.Im = falco.imaging.get_summed_image(mp, tb)
 
     elif mp.estimator in ['pairwise', 'pairwise-square', 'pairwise-rect',
                           'pwp-bp-square', 'pwp-bp', 'pwp-kf']:
 
         if mp.est.flagUseJac:  # Send in the Jacobian if true
-            falco.est.pairwise_probing(mp, ev, jacStruct=jacStruct)
+            falco.est.pairwise_probing(mp, ev, jacStruct=jacStruct, tb)
         else:  # Otherwise don't pass the Jacobian
-            falco.est.pairwise_probing(mp, ev)
+            falco.est.pairwise_probing(mp, ev, tb)
 
     return None
 
@@ -219,7 +221,7 @@ def _est_perfect_Efield_with_Zernikes_in_parallel(mp, ilist, inds_list):
     return E2D
 
 
-def pairwise_probing(mp, ev, jacStruct=np.array([])):
+def pairwise_probing(mp, ev, jacStruct=np.array([]), tb = None):
     """
     Estimate the dark hole E-field with pair-wise probing.
 
@@ -230,6 +232,8 @@ def pairwise_probing(mp, ev, jacStruct=np.array([])):
     ev : falco.config.Object()
     jacStruct : array_like, optional
         Array containing the control Jacobian. Default is an empty array.
+    tb : pyHCIT_hwControl.interface.TestbedInterface or None
+        (Optional) Control interface for a physical testbed.
 
     Returns
     -------
@@ -394,7 +398,7 @@ def pairwise_probing(mp, ev, jacStruct=np.array([])):
 
             # Take initial, unprobed image (for unprobed DM settings).
             whichImage = 0
-            I0 = falco.imaging.get_sbp_image(mp, iSubband)
+            I0 = falco.imaging.get_sbp_image(mp, iSubband, tb)
             I0vec = I0[mp.Fend.corr.maskBool]  # Vectorize the dark hole
 
             # Image already includes all stars, so don't sum over star loop
@@ -460,7 +464,7 @@ def pairwise_probing(mp, ev, jacStruct=np.array([])):
                     mp.dm2.V = DM2Vnom + dDM2Vprobe
 
                 # Take probed image
-                Im = falco.imaging.get_sbp_image(mp, iSubband)
+                Im = falco.imaging.get_sbp_image(mp, iSubband, tb)
 
                 # ImNonneg = Im
                 # ImNonneg[Im < 0] = 0

--- a/falco/est.py
+++ b/falco/est.py
@@ -41,9 +41,9 @@ def wrapper(mp, ev, jacStruct, tb = None):
                           'pwp-bp-square', 'pwp-bp', 'pwp-kf']:
 
         if mp.est.flagUseJac:  # Send in the Jacobian if true
-            falco.est.pairwise_probing(mp, ev, jacStruct=jacStruct, tb)
+            falco.est.pairwise_probing(mp, ev, jacStruct=jacStruct, tb=tb)
         else:  # Otherwise don't pass the Jacobian
-            falco.est.pairwise_probing(mp, ev, tb)
+            falco.est.pairwise_probing(mp, ev, tb=tb)
 
     return None
 

--- a/falco/imaging.py
+++ b/falco/imaging.py
@@ -4,6 +4,7 @@ import multiprocessing
 from concurrent.futures import ThreadPoolExecutor as PoolExecutor
 # from concurrent.futures import ProcessPoolExecutor as PoolExecutor
 import matplotlib.pyplot as plt
+from pyHCIT_hwControl.interface import TestbedInterface
 
 import falco
 from falco import check
@@ -246,7 +247,7 @@ def _model_full_norm_wrapper(mp, ilist, inds_list):
     return np.max(np.abs(Etemp)**2)
 
 
-def get_summed_image(mp):
+def get_summed_image(mp, tb = None):
     """
     Get the broadband image over the entire bandpass.
 
@@ -257,6 +258,8 @@ def get_summed_image(mp):
     ----------
     mp: falco.config.ModelParameters
         Structure of model parameters
+    tb: pyHCIT_hwControl.interface.TestbedInterface
+        (Optional) control interface for a physical testbed
 
     Returns
     -------
@@ -270,7 +273,7 @@ def get_summed_image(mp):
     if not (mp.flagParallel and mp.flagSim):
         summedImage = 0
         for si in range(mp.Nsbp):
-            summedImage += mp.sbp_weights[si] * get_sbp_image(mp, si)
+            summedImage += mp.sbp_weights[si] * get_sbp_image(mp, si, tb)
 
     else:  # Compute simulated images in parallel
 
@@ -360,7 +363,7 @@ def _get_single_sim_full_image(mp, ilist, vals_list):
     return np.abs(Estar)**2  # Apply spectral weighting outside this function
 
 
-def get_sbp_image(mp, si):
+def get_sbp_image(mp, si, tb = None):
     """
     Get an image in the specified sub-bandpass.
 
@@ -373,6 +376,8 @@ def get_sbp_image(mp, si):
         Structure of model parameters
     si: int
         Index of sub-bandpass for which to take the image
+    tb: pyHCIT_hwControl.interface.TestbedInterface or None
+        (Optional) Control interface for a physical testbed
 
     Returns
     -------
@@ -387,7 +392,10 @@ def get_sbp_image(mp, si):
     if mp.flagSim:
         Isbp = get_sim_sbp_image(mp, si)
     else:
-        Isbp = get_testbed_sbp_image(mp, si)
+        if type(tb) is not TestbedInterface:
+            raise TypeError('Input "tb" must be of type TestbedInterface')
+        tb.dm.apply(mp.dm1.V)
+        Isbp = tb.get_sbp_image(si)
 
     return Isbp
 

--- a/falco/imaging.py
+++ b/falco/imaging.py
@@ -392,8 +392,6 @@ def get_sbp_image(mp, si, tb = None):
     if mp.flagSim:
         Isbp = get_sim_sbp_image(mp, si)
     else:
-        if type(tb) is not TestbedInterface:
-            raise TypeError('Input "tb" must be of type TestbedInterface')
         tb.dm.apply(mp.dm1.V)
         Isbp = tb.get_sbp_image(si)
 

--- a/falco/imaging.py
+++ b/falco/imaging.py
@@ -4,7 +4,6 @@ import multiprocessing
 from concurrent.futures import ThreadPoolExecutor as PoolExecutor
 # from concurrent.futures import ProcessPoolExecutor as PoolExecutor
 import matplotlib.pyplot as plt
-from pyHCIT_hwControl.interface import TestbedInterface
 
 import falco
 from falco import check
@@ -258,7 +257,7 @@ def get_summed_image(mp, tb = None):
     ----------
     mp: falco.config.ModelParameters
         Structure of model parameters
-    tb: pyHCIT_hwControl.interface.TestbedInterface
+    tb: falco.config.TestbedInterface
         (Optional) control interface for a physical testbed
 
     Returns
@@ -376,7 +375,7 @@ def get_sbp_image(mp, si, tb = None):
         Structure of model parameters
     si: int
         Index of sub-bandpass for which to take the image
-    tb: pyHCIT_hwControl.interface.TestbedInterface or None
+    tb: falco.config.TestbedInterface or None
         (Optional) Control interface for a physical testbed
 
     Returns

--- a/falco/wfsc.py
+++ b/falco/wfsc.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 import falco
 
 
-def loop(mp, out):
+def loop(mp, out, tb = None):
     """
     Loop over the estimator and controller for WFSC.
 
@@ -19,6 +19,8 @@ def loop(mp, out):
         Structure of model parameters
     out : falco.config.Object
         Output variables
+    tb : pyHCIT_hwControl.interface.TestbedInterface or None
+        (Optional) Control interface for a physical testbed.
 
     Returns
     -------
@@ -90,7 +92,7 @@ def loop(mp, out):
         if Itr > 0:
             EestPrev = ev.Eest  # save previous estimate for Delta E plot
 
-        falco.est.wrapper(mp, ev, jacStruct)
+        falco.est.wrapper(mp, ev, jacStruct, tb)
 
         store_intensities(mp, out, ev, Itr)
 

--- a/falco/wfsc.py
+++ b/falco/wfsc.py
@@ -124,7 +124,7 @@ def loop(mp, out, tb = None):
 
         # Send a copy of jacStruct so that spatial weights don't show up 
         # outside the controller or get applied multiple times.
-        falco.ctrl.wrapper(mp, cvar, copy(jacStruct))
+        falco.ctrl.wrapper(mp, cvar, copy(jacStruct), tb=tb)
 
         # Store key data in out object
         out.log10regHist[Itr] = cvar.log10regUsed

--- a/falco/wfsc.py
+++ b/falco/wfsc.py
@@ -19,7 +19,7 @@ def loop(mp, out, tb = None):
         Structure of model parameters
     out : falco.config.Object
         Output variables
-    tb : pyHCIT_hwControl.interface.TestbedInterface or None
+    tb : falco.config.TestbedInterface or None
         (Optional) Control interface for a physical testbed.
 
     Returns


### PR DESCRIPTION
This is old code that I thought I had PR'ed and merged a long time ago. My bad. This PR adds a simple interface for getting an image from a test bed. If you provide something that implements that interface, falco will use the real image instead of generating one.